### PR TITLE
Add php7 curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,11 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 # install packages
 RUN \
  apk add --no-cache \
+ 	php7-curl \
 	php7-ldap \
 	php7-pdo_sqlite \
 	php7-sqlite3 \
 	php7-session \
-	php7-curl \
 	php7-zip
 
 # add local files

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN \
 	php7-pdo_sqlite \
 	php7-sqlite3 \
 	php7-session \
+	php7-curl \
 	php7-zip
 
 # add local files


### PR DESCRIPTION
Options like emby/plex auth need this to work. We already have ldap enabled so why not this? I tested it and it works fine. If it gets accepted I would test the other Versions and create a pull request